### PR TITLE
Update code for Stardew Valley 1.2 and SMAPI 2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,2 @@
-# Auto detect text files and perform LF normalization
+# always normalise line endings
 * text=auto
-
-# Custom for Visual Studio
-*.cs     diff=csharp
-
-# Standard to msysgit
-*.doc	 diff=astextplain
-*.DOC	 diff=astextplain
-*.docx diff=astextplain
-*.DOCX diff=astextplain
-*.dot  diff=astextplain
-*.DOT  diff=astextplain
-*.pdf  diff=astextplain
-*.PDF	 diff=astextplain
-*.rtf	 diff=astextplain
-*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,47 +1,25 @@
-# Windows image file caches
-Thumbs.db
-ehthumbs.db
+# user-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
 
-# Folder config file
-Desktop.ini
+# build results
+[Dd]ebug/
+[Rr]elease/
+[Bb]in/
+[Oo]bj/
 
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
+# Visual Studio cache/options
+.vs/
 
-# Windows Installer files
-*.cab
-*.msi
-*.msm
-*.msp
+# ReSharper
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
 
-# Windows shortcuts
-*.lnk
-
-# =========================
-# Operating System Files
-# =========================
-
-# OSX
-# =========================
-
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
+# NuGet packages
+*.nupkg
+**/packages/*
+*.nuget.props
+*.nuget.targets

--- a/WaitAroundSMAPI.sln
+++ b/WaitAroundSMAPI.sln
@@ -1,9 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WaitAroundSMAPI", "WaitAroundSMAPI\WaitAroundSMAPI.csproj", "{5F776EE1-2EF8-45D6-B062-87FFB9BECB32}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "metadata", "metadata", "{5C1C2AF2-0129-4275-8A96-ED68ACF741AD}"
+	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/WaitAroundSMAPI/MenuButton.cs
+++ b/WaitAroundSMAPI/MenuButton.cs
@@ -1,54 +1,54 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewValley;
+using StardewValley.Menus;
 
 namespace WaitAroundSMAPI
 {
-    class MenuButton
+    internal class MenuButton : ClickableTextureComponent
     {
-        public Action<MenuButton> callbackFunction { set; get; }
-        public Dictionary<String, String> callbackArgs;
-        public Texture2D buttonTex { set; get; }
-        public int relativeX { set; get; }
-        public int relativeY { set; get; }
-        public Rectangle buttonRect { set; get; }
-        public Vector2 parentMenuFactor { set; get; }
+        public Action<MenuButton> Callback { set; get; }
+        public int RelativeX { set; get; }
+        public int RelativeY { set; get; }
+        public Vector2 ParentMenuFactor { set; get; }
 
-        public MenuButton(int width, int height, int x, int y, Vector2 parentMenuFactor, Rectangle parentMenu, Texture2D buttonTex, Action<MenuButton> callbackFunction)
+        public MenuButton(string name, int relativeX, int relativeY, int spriteWidth, int spriteHeight, Vector2 parentMenuFactor, Rectangle parentMenu, Texture2D spritesheet, int spritePosition, Action<MenuButton> callback)
+            : base(
+                name: name,
+                label: null,
+                hoverText: null,
+                bounds: new Rectangle(0, 0, spriteWidth, spriteHeight),
+                texture: spritesheet,
+                sourceRect: Game1.getSourceRectForStandardTileSheet(spritesheet, spritePosition, spriteWidth, spriteHeight),
+                scale: 1
+            )
         {
-            this.relativeX = x;
-            this.relativeY = y;
-            this.parentMenuFactor = parentMenuFactor;
+            this.RelativeX = relativeX;
+            this.RelativeY = relativeY;
+            this.ParentMenuFactor = parentMenuFactor;
+            this.Callback = callback;
 
-            this.buttonRect = new Rectangle(0, 0, width, height);
-            this.setAbsoluteButtonPosition(parentMenu);
-
-            this.buttonTex = buttonTex;
-
-            this.callbackFunction = callbackFunction;
-            this.callbackArgs = new Dictionary<String, String>();
+            this.SetAbsolutePosition(parentMenu);
         }
+
         public void Draw(SpriteBatch b, Rectangle parentMenu)
         {
-            this.setAbsoluteButtonPosition(parentMenu);
-            b.Draw(this.buttonTex, this.buttonRect, new Rectangle(0, 0, this.buttonTex.Width, this.buttonTex.Height), Color.White, 0f, Vector2.Zero, SpriteEffects.None, 1f);
+            this.SetAbsolutePosition(parentMenu);
+            base.draw(b);
         }
 
-        private void setAbsoluteButtonPosition(Rectangle parentMenu)
+        private void SetAbsolutePosition(Rectangle parentMenu)
         {
-            int finalButtonX = parentMenu.X + this.relativeX + (int)Math.Floor(parentMenu.Width * this.parentMenuFactor.X);
-            if (this.relativeX + (int)Math.Floor(parentMenu.Width * this.parentMenuFactor.X) < 0)
-            {
-                finalButtonX = parentMenu.X + parentMenu.Width + this.relativeX + (int)Math.Floor(parentMenu.Width * this.parentMenuFactor.X);
-            }
+            int x = parentMenu.X + this.RelativeX + (int)Math.Floor(parentMenu.Width * this.ParentMenuFactor.X);
+            if (this.RelativeX + (int)Math.Floor(parentMenu.Width * this.ParentMenuFactor.X) < 0)
+                x = parentMenu.X + parentMenu.Width + this.RelativeX + (int)Math.Floor(parentMenu.Width * this.ParentMenuFactor.X);
 
-            int finalButtonY = parentMenu.Y + this.relativeY + (int)Math.Floor(parentMenu.Height * this.parentMenuFactor.Y);
-            if (this.relativeY + (int)Math.Floor(parentMenu.Height * this.parentMenuFactor.Y) < 0)
-            {
-                finalButtonY = parentMenu.Y + parentMenu.Height + this.relativeY + (int)Math.Floor(parentMenu.Height * this.parentMenuFactor.Y);
-            }
-            this.buttonRect = new Rectangle(finalButtonX, finalButtonY, this.buttonRect.Width, this.buttonRect.Height);
+            int y = parentMenu.Y + this.RelativeY + (int)Math.Floor(parentMenu.Height * this.ParentMenuFactor.Y);
+            if (this.RelativeY + (int)Math.Floor(parentMenu.Height * this.ParentMenuFactor.Y) < 0)
+                y = parentMenu.Y + parentMenu.Height + this.RelativeY + (int)Math.Floor(parentMenu.Height * this.ParentMenuFactor.Y);
+
+            this.bounds = new Rectangle(x, y, this.bounds.Width, this.bounds.Height);
         }
 
     }

--- a/WaitAroundSMAPI/Properties/AssemblyInfo.cs
+++ b/WaitAroundSMAPI/Properties/AssemblyInfo.cs
@@ -1,36 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("WaitAroundSMAPI")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("WaitAroundSMAPI")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("5f776ee1-2ef8-45d6-b062-87ffb9becb32")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1")]
+[assembly: AssemblyFileVersion("1.0.1")]

--- a/WaitAroundSMAPI/WaitAroundConfig.cs
+++ b/WaitAroundSMAPI/WaitAroundConfig.cs
@@ -1,26 +1,9 @@
 ﻿using StardewModdingAPI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace WaitAroundSMAPI
 {
-    class WaitAroundConfig : Config
+    internal class WaitAroundConfig
     {
-        public override string ConfigLocation
-        {
-            get
-            {
-                return "WaitAround\\config.cfg";
-            }
-        }
-        public string menuKey { get; set; }
-        public override T GenerateDefaultConfig<T>()
-        {
-            menuKey = "K";
-            return this as T;
-        }
+        public SButton menuKey { get; set; } = SButton.K;
     }
 }

--- a/WaitAroundSMAPI/WaitAroundMod.cs
+++ b/WaitAroundSMAPI/WaitAroundMod.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.Xna.Framework.Input;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewValley;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using StardewModdingAPI.Events;
 
 namespace WaitAroundSMAPI
 {
-    public class WaitAroundMod : Mod
+    internal class WaitAroundMod : Mod
     {
         private static int LatestTime = 2550;
         private int _timeToWait;
@@ -33,33 +28,23 @@ namespace WaitAroundSMAPI
                 }
             }
         }
-        private Keys menuKey { get; set; }
         private WaitAroundMenu waitMenu { get; set; }
         private WaitAroundConfig config { get; set; }
 
-        public override void Entry(params object[] objects)
+        public override void Entry(IModHelper helper)
         {
-            config = new WaitAroundConfig().LoadConfig<WaitAroundConfig>();
-            menuKey = (Keys)Enum.Parse(typeof(Keys), config.menuKey.ToUpper());
-            KeyboardInput.KeyDown += KeyPressed;
+            config = helper.ReadConfig<WaitAroundConfig>();
+            InputEvents.ButtonPressed += KeyPressed;
         }
 
-        public void KeyPressed(object sender, KeyEventArgs e)
+        public void KeyPressed(object sender, EventArgsInput e)
         {
-            if (e.KeyCode.Equals(menuKey) && Game1.hasLoadedGame)
+            if (e.Button == config.menuKey && Context.IsWorldReady)
             {
-                if (Game1.activeClickableMenu == null)
-                {
-                    // this will bug animation frames if you don't prevent it
-                    if (!Game1.player.usingTool)
-                    {
-                        Game1.activeClickableMenu = new WaitAroundMenu(this);
-                    }
-                }
+                if (Game1.activeClickableMenu == null && Context.IsPlayerFree)
+                    Game1.activeClickableMenu = new WaitAroundMenu(this);
                 else if(Game1.activeClickableMenu is WaitAroundMenu)
-                {
                     ((WaitAroundMenu)Game1.activeClickableMenu).Close();
-                }
             }
         }
 

--- a/WaitAroundSMAPI/WaitAroundSMAPI.csproj
+++ b/WaitAroundSMAPI/WaitAroundSMAPI.csproj
@@ -30,41 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Downloads\StardewValley.v1.05\Microsoft.Xna.Framework.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Windows\Microsoft.NET\assembly\GAC_32\Microsoft.Xna.Framework.Game\v4.0_4.0.0.0__842cf8be1de50553\Microsoft.Xna.Framework.Game.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Windows\Microsoft.NET\assembly\GAC_32\Microsoft.Xna.Framework.Graphics\v4.0_4.0.0.0__842cf8be1de50553\Microsoft.Xna.Framework.Graphics.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>..\..\..\..\..\Downloads\StardewValley.v1.05\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\..\..\SMAPI\StardewModdingAPI\bin\x86\Debug\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="xTile">
-      <HintPath>..\..\..\..\..\Downloads\StardewValley.v1.05\xTile.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="WaitAroundConfig.cs" />
@@ -77,13 +44,14 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/WaitAroundSMAPI/manifest.json
+++ b/WaitAroundSMAPI/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "WaitAround",
   "Author": "Alhifar",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Description": "Wait around for something to happen",
   "UniqueID": "Alhifar.WaitAround",
   "EntryDll": "WaitAroundSMAPI.dll",

--- a/WaitAroundSMAPI/manifest.json
+++ b/WaitAroundSMAPI/manifest.json
@@ -1,13 +1,10 @@
 {
   "Name": "WaitAround",
-  "Authour": "Alhifar",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 0,
-    "Build": ""
-  },
+  "Author": "Alhifar",
+  "Version": "1.0.0",
   "Description": "Wait around for something to happen",
-  "PerSaveConfigs": false,
-  "EntryDll": "WaitAroundSMAPI.dll"
+  "UniqueID": "Alhifar.WaitAround",
+  "EntryDll": "WaitAroundSMAPI.dll",
+  "MinimumApiVersion": "2.0",
+  "UpdateKeys": []
 }

--- a/WaitAroundSMAPI/packages.config
+++ b/WaitAroundSMAPI/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
This pull request...
* Updates the code for compatibility with SMAPI 2.0+ and Stardew Valley 1.2+.
* Migrates to the [mod build package](https://github.com/Pathoschild/Stardew.ModBuildConfig).  
    _This automates references (so we no longer need to change reference paths in the `.csproj`), lets us compile the mod on Linux/Mac/Windows without changes, simplifies debugging from Visual Studio, lets us deploy the mod into the game's `Mods` folder automatically on build, and creates the release package automatically._
* Simplifies the `.gitattributes` and replaces the `.gitignore` with one for C# projects.
* Bumps the version to 1.0.1 for release.

If these changes look fine, can you release [WaitAround 1.0.1.zip](https://github.com/Alhifar/WaitAroundSMAPI/files/1609419/WaitAround.1.0.1.zip) to the [forum thread](https://community.playstarbound.com/threads/smapi-waitaround.111630/)?