### PR TITLE
Enable update checks

### DIFF
--- a/WaitAroundSMAPI/Properties/AssemblyInfo.cs
+++ b/WaitAroundSMAPI/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyTitle("WaitAroundSMAPI")]
-[assembly: AssemblyVersion("1.0.1")]
-[assembly: AssemblyFileVersion("1.0.1")]
+[assembly: AssemblyVersion("1.2.1")]
+[assembly: AssemblyFileVersion("1.2.1")]

--- a/WaitAroundSMAPI/manifest.json
+++ b/WaitAroundSMAPI/manifest.json
@@ -6,5 +6,5 @@
   "UniqueID": "Alhifar.WaitAround",
   "EntryDll": "WaitAroundSMAPI.dll",
   "MinimumApiVersion": "2.0",
-  "UpdateKeys": []
+  "UpdateKeys": [ "GitHub:Alhifar/WaitAroundSMAPI" ]
 }

--- a/WaitAroundSMAPI/manifest.json
+++ b/WaitAroundSMAPI/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "WaitAround",
   "Author": "Alhifar",
-  "Version": "1.0.1",
+  "Version": "1.2.1",
   "Description": "Wait around for something to happen",
   "UniqueID": "Alhifar.WaitAround",
   "EntryDll": "WaitAroundSMAPI.dll",


### PR DESCRIPTION
This pull request enables [automatic update checks](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Update_checks). With this change, SMAPI will...
1. get the latest release version from this GitHub repository on startup;
2. compare it to the local `manifest.json` version;
3. show a message like this if newer:
   > ![](https://user-images.githubusercontent.com/230581/34707096-8843fb08-f4d9-11e7-9143-eaf50ecd46e7.png)

The `manifest.json` version in this pull request is 1.2.1; you should edit that if you'll use a different version on GitHub to avoid false update alerts. :)